### PR TITLE
chore: standardize dependency version ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Para empezar de cero, borra:
 
 Ver archivo `requirements.txt`.
 
+> **Compatibilidad:** las dependencias están fijadas con versiones mínimas (`>=`).
+> Se ha probado con las versiones listadas, pero versiones superiores no se han verificado exhaustivamente.
+
 ## 📜 Licencia
 
 MIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.116.1
+fastapi>=0.116.1
 uvicorn>=0.30
 gradio>=4.44
 opencv-python>=4.9


### PR DESCRIPTION
## Summary
- use consistent `>=` version ranges for all Python dependencies
- note minimal-version compatibility in README

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aebab66f8c8331ae1af70db4354550